### PR TITLE
Yr

### DIFF
--- a/src/components/TextTab/index.jsx
+++ b/src/components/TextTab/index.jsx
@@ -41,8 +41,6 @@ export const TextTab = (canvas, imgFile) =>{
         imgFile.selectable = false;
         
         canvas.add(imgFile);
-        // canvas.renderAll();
-    
   });
     }
     
@@ -52,7 +50,7 @@ export const TextTab = (canvas, imgFile) =>{
     <>
     <s.ContainerText>
       <s.BtnAddText onClick = {AddText}>TEXT</s.BtnAddText>
-      <s.BtnImageFix onClick = {FixImage}>이미지 고정</s.BtnImageFix>
+      <s.BtnFixImage onClick = {FixImage}>이미지 고정</s.BtnFixImage>
     </s.ContainerText>
     
     </>

--- a/src/components/TextTab/styles.js
+++ b/src/components/TextTab/styles.js
@@ -8,5 +8,5 @@ export const BtnAddText = styled.button`
 
 `
 
-export const BtnImageFix = styled.button`
+export const BtnFixImage = styled.button`
 `


### PR DESCRIPTION
## 작업 내용
> 이미지를 도장찍듯이 배경에 고정할 수 있는 버튼을 만듦

<br/>

## 변동 내용
> 고정하고자 하는 이미지를 선택한 상태에서 이미지 고정 버튼을 누르면 그 위치에 그 크기 그대로 이미지가 배경에 고정됨
<br/>

## 자료 첨부
> 카카오톡 참고

<br/>

## 중점으로 리뷰받고 싶은 내용
> 다만, 이미지를 회전한 상태에서는 회전이 반영되지 않고, 회전율이 크면 클 수록 이미지가 작아지는 문제가 있음
> 따라서 회전된 이미지는 고정할 수 없다는 한계가 있음

<br/>

## 참고자료
> https://m.blog.naver.com/PostView.naver?isHttpsRedirect=true&blogId=freegunkng&logNo=220954153648
